### PR TITLE
Accept without personal number

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ $ composer require dimafe6/bank-id
 ```
 
 ## Usage
+Either you let the user enter their personal number and pass to BankID or you only pass the order ref and receive the
+personal number from the response from BankID.
 
 ```php
 <?php
@@ -48,7 +50,10 @@ $bankIDService = new BankIDService(
         'ssl_key'   => 'PATH_TO_TEST_CERT.key',
     ]
 );
+```
 
+##### Example with personal number
+```php
 // Signing. Step 1 - Get orderRef
 /** @var OrderResponse $response */
 $response = $bankIDService->getSignResponse('PERSONAL_NUMBER', 'User visible data');
@@ -77,6 +82,20 @@ $response = $bankIDService->getAuthResponse('PERSONAL_NUMBER');
 // Cancel authorize order
 if($bankIDService->cancelOrder($response->orderRef)) {
     return 'Authorization canceled';
+}
+```
+
+##### Example without personal number
+```php
+// Authorize. Step 1 - Get orderRef
+$response = $bankIDService->getAuthResponse();
+
+// Authorize. Step 2 - Collect orderRef. 
+// Repeat until $authResponse->status !== CollectResponse::STATUS_COMPLETED
+$authResponse = $bankIDService->collectResponse($response->orderRef);
+if($authResponse->status == CollectResponse::STATUS_COMPLETED) {
+    echo $authResponse->completionData->user->personalNumber;
+    return true; //Authorized
 }
 ```
 

--- a/src/Service/BankIDService.php
+++ b/src/Service/BankIDService.php
@@ -48,19 +48,21 @@ class BankIDService
     }
 
     /**
-     * @param string $personalNumber The personal number of the user. String. 12 digits. Century must be included.
+     * @param string|null $personalNumber The personal number of the user. String. 12 digits. Century must be included.
      * @return OrderResponse
      * @throws ClientException
      */
-    public function getAuthResponse($personalNumber)
+    public function getAuthResponse($personalNumber = null)
     {
         $parameters = [
-            'personalNumber' => $personalNumber,
             'endUserIp'      => $this->endUserIp,
             'requirement'    => [
                 'allowFingerprint' => true,
             ],
         ];
+        if ($personalNumber) {
+            $parameters['personalNumber'] = $personalNumber;
+        }
 
         $responseData = $this->client->post('auth', ['json' => $parameters]);
 
@@ -71,7 +73,7 @@ class BankIDService
 
 
     /**
-     * @param string $personalNumber The personal number of the user. String. 12 digits. Century must be included.
+     * @param string|null $personalNumber The personal number of the user. String. 12 digits. Century must be included.
      * @param string $userVisibleData The text to be displayed and signed.
      * @param string $userHiddenData Data not displayed to the user
      * @return OrderResponse
@@ -80,13 +82,15 @@ class BankIDService
     public function getSignResponse($personalNumber, $userVisibleData, $userHiddenData = '')
     {
         $parameters = [
-            'personalNumber'  => $personalNumber,
             'endUserIp'       => $this->endUserIp,
             'userVisibleData' => base64_encode($userVisibleData),
             'requirement'     => [
                 'allowFingerprint' => true,
             ],
         ];
+        if ($personalNumber) {
+            $parameters['personalNumber'] = $personalNumber;
+        }
 
         if (!empty($userHiddenData)) {
             $parameters['userNonVisibleData'] = base64_encode($userHiddenData);

--- a/tests/Service/BankIDServiceTest.php
+++ b/tests/Service/BankIDServiceTest.php
@@ -44,6 +44,22 @@ class BankIDServiceTest extends TestCase
     }
 
     /**
+     * @return OrderResponse
+     */
+    public function testSignResponseWithoutPersonalNumber()
+    {
+        $signResponse = $this->bankIDService->getSignResponse(
+            null,
+            'userVisibleData',
+            'userNonVisibleData'
+        );
+
+        $this->assertInstanceOf(OrderResponse::class, $signResponse);
+
+        return $signResponse;
+    }
+
+    /**
      * @depends testSignResponse
      * @param OrderResponse $signResponse
      * @return \Dimafe6\BankID\Model\CollectResponse
@@ -73,6 +89,18 @@ class BankIDServiceTest extends TestCase
     public function testAuthResponse()
     {
         $authResponse = $this->bankIDService->getAuthResponse(self::TEST_PERSONAL_NUMBER);
+
+        $this->assertInstanceOf(OrderResponse::class, $authResponse);
+
+        return $authResponse;
+    }
+
+    /**
+     * @return OrderResponse
+     */
+    public function testAuthResponseWithoutPersonalNumber()
+    {
+        $authResponse = $this->bankIDService->getAuthResponse();
 
         $this->assertInstanceOf(OrderResponse::class, $authResponse);
 

--- a/tests/Service/BankIDServiceTest.php
+++ b/tests/Service/BankIDServiceTest.php
@@ -44,6 +44,30 @@ class BankIDServiceTest extends TestCase
     }
 
     /**
+     * @depends testSignResponse
+     * @param OrderResponse $signResponse
+     * @return \Dimafe6\BankID\Model\CollectResponse
+     */
+    public function testCollectSignResponse($signResponse)
+    {
+        $this->assertInstanceOf(OrderResponse::class, $signResponse);
+
+        $attempts = 0;
+        do {
+            fwrite(STDOUT, "\nWaiting confirmation from BankID application...\n");
+            sleep(10);
+
+            $collectResponse = $this->bankIDService->collectResponse($signResponse->orderRef);
+            $attempts++;
+        } while ($collectResponse->status !== CollectResponse::STATUS_COMPLETED && $attempts <= 6);
+
+        $this->assertInstanceOf(CollectResponse::class, $collectResponse);
+        $this->assertEquals(CollectResponse::STATUS_COMPLETED, $collectResponse->status);
+
+        return $collectResponse;
+    }
+
+    /**
      * @return OrderResponse
      */
     public function testSignResponseWithoutPersonalNumber()
@@ -59,12 +83,13 @@ class BankIDServiceTest extends TestCase
         return $signResponse;
     }
 
+
     /**
-     * @depends testSignResponse
+     * @depends testSignResponseWithoutPersonalNumber
      * @param OrderResponse $signResponse
      * @return \Dimafe6\BankID\Model\CollectResponse
      */
-    public function testCollectSignResponse($signResponse)
+    public function testCollectSignResponseWithoutPersonalNumber($signResponse)
     {
         $this->assertInstanceOf(OrderResponse::class, $signResponse);
 
@@ -96,6 +121,30 @@ class BankIDServiceTest extends TestCase
     }
 
     /**
+     * @depends testAuthResponse
+     * @param OrderResponse $authResponse
+     * @return \Dimafe6\BankID\Model\CollectResponse
+     */
+    public function testCollectAuthResponse($authResponse)
+    {
+        $this->assertInstanceOf(OrderResponse::class, $authResponse);
+
+        $attempts = 0;
+        do {
+            fwrite(STDOUT, "\nWaiting confirmation from BankID application...\n");
+            sleep(10);
+
+            $collectResponse = $this->bankIDService->collectResponse($authResponse->orderRef);
+            $attempts++;
+        } while ($collectResponse->status !== CollectResponse::STATUS_COMPLETED && $attempts <= 6);
+
+        $this->assertInstanceOf(CollectResponse::class, $collectResponse);
+        $this->assertEquals(CollectResponse::STATUS_COMPLETED, $collectResponse->status);
+
+        return $collectResponse;
+    }
+
+    /**
      * @return OrderResponse
      */
     public function testAuthResponseWithoutPersonalNumber()
@@ -108,11 +157,11 @@ class BankIDServiceTest extends TestCase
     }
 
     /**
-     * @depends testAuthResponse
+     * @depends testAuthResponseWithoutPersonalNumber
      * @param OrderResponse $authResponse
      * @return \Dimafe6\BankID\Model\CollectResponse
      */
-    public function testCollectAuthResponse($authResponse)
+    public function testCollectAuthResponseWithoutPersonalNumber($authResponse)
     {
         $this->assertInstanceOf(OrderResponse::class, $authResponse);
 


### PR DESCRIPTION
### Description
Passing personal number is optional.

### Checklist
- [x] Code compiles correctly
- [x] Code conforms PSR-2. Recommending use PHP CS Fixer with next rules: `--rules=@PSR2,blank_line_before_return,no_unused_imports`
- [ ] Created tests which fail without the change (if possible)
- [ ] All tests passing
- [x] Extended the README, if necessary
- [ ] Added myself / the copyright holder to the authors in composer.json file