### PR TITLE
Add support for Laravel 8.0 with support for guzzle 7.0.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "6.3.*"
+        "guzzlehttp/guzzle": "^7.0.*"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.* || 6.3.*"

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "guzzlehttp/guzzle": "^7.0.*"
+        "guzzlehttp/guzzle": "^7.0.1"
     },
     "require-dev": {
         "phpunit/phpunit": "5.7.* || 6.3.*"


### PR DESCRIPTION
### Description
Add support for Laravel 8.0 with support for guzzle 7.0.*.

### Checklist
- [x] Code compiles correctly
- [x] Code conforms PSR-2. Recommending use PHP CS Fixer with next rules: `--rules=@PSR2,blank_line_before_return,no_unused_imports`
- [x] Created tests which fail without the change (if possible)
- [x] All tests passing
- [x] Extended the README, if necessary
- [x] Added myself / the copyright holder to the authors in composer.json file